### PR TITLE
Fixing json dumps bug

### DIFF
--- a/library/artifactory_groups.py
+++ b/library/artifactory_groups.py
@@ -261,7 +261,7 @@ def main():
         sec_dict.update(group_config)
     if group_config_dict:
         sec_dict.update(group_config_dict)
-    group_config = json.dumps(sec_dict)
+    group_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "
                                   "within artifactory '%s'"

--- a/library/artifactory_permissions.py
+++ b/library/artifactory_permissions.py
@@ -139,6 +139,21 @@ EXAMPLES = '''
        - two-repo
     state: present
 
+# Create a permission target using top-level parameters and using
+# perm_config_dict to set group permissions.
+- name: create a permission target
+  artifactory_permissions:
+    artifactory_url: http://art.url.com/artifactory/api/security/permissions
+    auth_token: MY_TOKEN
+    name: temp-perm
+    repositories:
+       - one-repo
+       - two-repo
+    perm_config_dict:
+       principals:
+          groups: '{"the_group": ["w", "r"]}'
+    state: present
+
 # Replace the artifactory permission target with the latest version
 - name: Replace the permission target with latest config
   artifactory_permissions:
@@ -301,7 +316,7 @@ def main():
         sec_dict.update(perm_config)
     if perm_config_dict:
         sec_dict.update(perm_config_dict)
-    perm_config = json.dumps(sec_dict)
+    perm_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "
                                   "within artifactory '%s'"

--- a/library/artifactory_replication.py
+++ b/library/artifactory_replication.py
@@ -336,7 +336,7 @@ def main():
         sec_dict.update(replication_config)
     if replication_config_dict:
         sec_dict.update(replication_config_dict)
-    replication_config = json.dumps(sec_dict)
+    replication_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "
                                   "within artifactory '%s'"

--- a/library/artifactory_repo.py
+++ b/library/artifactory_repo.py
@@ -152,6 +152,7 @@ options:
         choices:
           - bower
           - chef
+          - cocoapods
           - composer
           - conan
           - debian
@@ -160,15 +161,17 @@ options:
           - generic
           - gitlfs
           - gradle
+          - helm
           - ivy
           - maven
           - npm
           - nuget
+          - opkg
           - puppet
           - pypi
+          - rpm
           - sbt
           - vagrant
-          - yum
     repo_config_dict:
         description:
             - A dictionary in yaml format of valid configuration values. These
@@ -319,6 +322,7 @@ VALID_RCLASSES = [LOCAL_RCLASS, REMOTE_RCLASS, VIRTUAL_RCLASS]
 
 VALID_PACKAGETYPES = ["bower",
                       "chef",
+                      "cocoapads",
                       "composer",
                       "conan",
                       "debian",
@@ -327,15 +331,17 @@ VALID_PACKAGETYPES = ["bower",
                       "generic",
                       "gitlfs",
                       "gradle",
+                      "helm",
                       "ivy",
                       "maven",
                       "npm",
                       "nuget",
+                      "opkg",
                       "puppet",
                       "pypi",
+                      "rpm",
                       "sbt",
-                      "vagrant",
-                      "yum"]
+                      "vagrant"]
 
 KEY_CONFIG_MAP = {
     "rclass":
@@ -492,7 +498,7 @@ def main():
         repo_dict.update(repo_config)
     if repo_config_dict:
         repo_dict.update(repo_config_dict)
-    repo_config = json.dumps(repo_dict)
+    repo_config = str(repo_dict)
 
     result['original_message'] = ("Perform state '%s' against repo '%s' "
                                   "within artifactory '%s'"
@@ -512,7 +518,7 @@ def main():
         force_basic_auth=force_basic_auth,
         config_map=URI_CONFIG_MAP)
 
-    art_base.run_module(module, art_repo, "groups", result,
+    art_base.run_module(module, art_repo, "repos", result,
                         fail_messages, repo_config)
 
 

--- a/library/artifactory_users.py
+++ b/library/artifactory_users.py
@@ -284,7 +284,7 @@ def main():
         sec_dict.update(user_config)
     if user_config_dict:
         sec_dict.update(user_config_dict)
-    user_config = json.dumps(sec_dict)
+    user_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "
                                   "within artifactory '%s'"


### PR DESCRIPTION
Converting the initial dictionary back into a string using JSON dumps
resulted in a ValueError exception when attempting to convert that same
string back to a dictionary using ast.literal_eval since booleans in
JSON are lowercase true/false. Doing a straight cast avoids this
problem. Thanks keekz!