### PR TITLE
API allows multi-case for LDAP groups while UI only allows lower

### DIFF
--- a/library/artifactory_groups.py
+++ b/library/artifactory_groups.py
@@ -47,7 +47,11 @@ options:
     name:
         description:
             - Name of the artifactory security group target to perform
-              CRUD operations against.
+              CRUD operations against. WARNING: The UI will enforce lowercase
+              when importing LDAP groups, but the API side WILL not. If you are
+              creating LDAP groups via the API, you will need to make sure all
+              LDAP group names are lowercase since this will impact how
+              Artifactory matches. See Artifactory Knowledge Article: 000001563
         required: true
     group_config:
         description:
@@ -173,7 +177,6 @@ config:
 
 
 import ast
-import json
 
 import ansible.module_utils.artifactory as art_base
 

--- a/library/artifactory_permissions.py
+++ b/library/artifactory_permissions.py
@@ -194,7 +194,6 @@ config:
     type: dict
 '''
 import ast
-import json
 
 import ansible.module_utils.artifactory as art_base
 

--- a/library/artifactory_replication.py
+++ b/library/artifactory_replication.py
@@ -187,7 +187,6 @@ config:
     type: dict
 '''
 import ast
-import json
 
 import ansible.module_utils.artifactory as art_base
 

--- a/library/artifactory_repo.py
+++ b/library/artifactory_repo.py
@@ -307,7 +307,6 @@ config:
 
 
 import ast
-import json
 
 import ansible.module_utils.artifactory as art_base
 

--- a/library/artifactory_users.py
+++ b/library/artifactory_users.py
@@ -175,7 +175,6 @@ config:
     type: dict
 '''
 import ast
-import json
 
 import ansible.module_utils.artifactory as art_base
 


### PR DESCRIPTION
Removed unused import json.

Artifactory API allows LDAP groups to be any case, while the UI enforces
lowercase only for imported LDAP groups. To highlight this problem,
the documentation has been updated instead of enforcing lowercase on the
name in the module. Determining whether or not a new group is an LDAP group or
an Artifactory security group could become brittle, so it was decided that a
warning in documentation would be the best compromise.

For completeness, the document number from the Artifactory support site
describing how LDAP groups are treated has been included:

"How do I configure Artifactory SAML SSO with ADFS?

Knowledge Article Number: 000001563
Published Date: 2017-07-23 14:06"