### PR TITLE
Add new repo types and fix typo

### DIFF
--- a/library/artifactory_repo.py
+++ b/library/artifactory_repo.py
@@ -350,7 +350,8 @@ VALID_PACKAGETYPES = ["bower",
                       "rpm",
                       "sbt",
                       "vagrant",
-                      "vcs"]
+                      "vcs"
+                     ]
 
 KEY_CONFIG_MAP = {
     "rclass":

--- a/library/artifactory_repo.py
+++ b/library/artifactory_repo.py
@@ -155,11 +155,14 @@ options:
           - cocoapods
           - composer
           - conan
+          - conda
+          - cran
           - debian
           - docker
           - gems
           - generic
           - gitlfs
+          - go
           - gradle
           - helm
           - ivy
@@ -167,11 +170,13 @@ options:
           - npm
           - nuget
           - opkg
+          - p2
           - puppet
           - pypi
           - rpm
           - sbt
           - vagrant
+          - vcs
     repo_config_dict:
         description:
             - A dictionary in yaml format of valid configuration values. These
@@ -321,14 +326,17 @@ VALID_RCLASSES = [LOCAL_RCLASS, REMOTE_RCLASS, VIRTUAL_RCLASS]
 
 VALID_PACKAGETYPES = ["bower",
                       "chef",
-                      "cocoapads",
+                      "cocoapods",
                       "composer",
                       "conan",
+                      "conda",
+                      "cran",
                       "debian",
                       "docker",
                       "gems",
                       "generic",
                       "gitlfs",
+                      "go",
                       "gradle",
                       "helm",
                       "ivy",
@@ -336,11 +344,13 @@ VALID_PACKAGETYPES = ["bower",
                       "npm",
                       "nuget",
                       "opkg",
+                      "p2",
                       "puppet",
                       "pypi",
                       "rpm",
                       "sbt",
-                      "vagrant"]
+                      "vagrant",
+                      "vcs"]
 
 KEY_CONFIG_MAP = {
     "rclass":


### PR DESCRIPTION
New repo types with 6.x

Fixed typo on cocoapods
