### PR TITLE
WIP: Add urllib.parse.quote when creating working_url

### DIFF
--- a/lib/ansible/module_utils/artifactory.py
+++ b/lib/ansible/module_utils/artifactory.py
@@ -31,6 +31,7 @@ import ast
 import json
 
 from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import open_url
 
 """
@@ -77,7 +78,9 @@ class ArtifactoryBase(object):
             self.headers["X-JFrog-Art-Api"] = auth_token
 
         if self.name:
-            self.working_url = '%s/%s' % (self.artifactory_url, self.name)
+            # escape invalid url characters
+            self.working_url = '%s/%s' % (self.artifactory_url,
+                                          quote(self.name))
         else:
             self.working_url = self.artifactory_url
 
@@ -91,6 +94,7 @@ class ArtifactoryBase(object):
         return self.query_artifactory(self.working_url, 'DELETE')
 
     def create_artifactory_target(self):
+        # This is not a mistake. POST == PUT in artifactory land
         method = 'PUT'
         serial_config_data = self.get_valid_conf(method)
         create_target_url = self.working_url
@@ -98,6 +102,7 @@ class ArtifactoryBase(object):
                                       data=serial_config_data)
 
     def update_artifactory_target(self):
+        # This is not a mistake. PUT == POST in artifactory land
         method = 'POST'
         serial_config_data = self.get_valid_conf(method)
         return self.query_artifactory(self.working_url, method,

--- a/library/artifactory_groups.py
+++ b/library/artifactory_groups.py
@@ -264,6 +264,11 @@ def main():
         sec_dict.update(group_config)
     if group_config_dict:
         sec_dict.update(group_config_dict)
+    # Artifactory stores the group name as lowercase (even if it was passed as
+    # multi-case). Calls against that group after it is created will fail
+    # since artifactory only recognizes the lower case name.
+    sec_dict['name'] = sec_dict['name'].lower()
+    name = name.lower()
     group_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "

--- a/library/artifactory_permissions.py
+++ b/library/artifactory_permissions.py
@@ -315,6 +315,11 @@ def main():
         sec_dict.update(perm_config)
     if perm_config_dict:
         sec_dict.update(perm_config_dict)
+    # Artifactory stores the name as lowercase (even if it was passed as
+    # multi-case). Calls against that name after it is created will fail
+    # since artifactory only recognizes the lower case name.
+    sec_dict['name'] = sec_dict['name'].lower()
+    name = name.lower()
     perm_config = str(sec_dict)
 
     result['original_message'] = ("Perform state '%s' against target '%s' "


### PR DESCRIPTION
Currently, working url takes the name provided by the ansible module. If
this name contains spaces, however, it'll result in an error. As it
should. This upgrade takes the "name" provided from ansible modules and
escapes the characters so that we can make calls properly.