### PR TITLE
Add alpine to supported package types

### DIFF
--- a/library/artifactory_repo.py
+++ b/library/artifactory_repo.py
@@ -150,6 +150,7 @@ options:
             - The packageType of the repository.
         required: false
         choices:
+          - alpine
           - bower
           - chef
           - cocoapods
@@ -324,7 +325,8 @@ VIRTUAL_RCLASS = "virtual"
 
 VALID_RCLASSES = [LOCAL_RCLASS, REMOTE_RCLASS, VIRTUAL_RCLASS]
 
-VALID_PACKAGETYPES = ["bower",
+VALID_PACKAGETYPES = ["alpine",
+                      "bower",
                       "chef",
                       "cocoapods",
                       "composer",


### PR DESCRIPTION
Adds new supported package 'alpine' to the package list.

https://www.jfrog.com/confluence/display/JFROG/Package+Management

resolves #20